### PR TITLE
feat: little optimizations to minimax AI

### DIFF
--- a/src/commands/board.zig
+++ b/src/commands/board.zig
@@ -5,6 +5,8 @@ const message = @import("../message.zig");
 const main = @import("../main.zig");
 const game = @import("../game.zig");
 const ai = @import("../ai.zig");
+const turn = @import("turn.zig");
+
 
 var stdin = std.io.getStdIn().reader().any();
 
@@ -93,10 +95,11 @@ fn handleBoard (
         );
     }
     // Send coordinates.
-    const empty_cell = ai.findBestMove(&board.game_board);
-    board.game_board.setCellByCoordinates(empty_cell.col, empty_cell.row, board.Cell.own);
-    try message.sendMessageF("{d},{d}", .{empty_cell.col, empty_cell.row}, writer);
-    return;
+    const ai_move = turn.AIPlay();
+
+    // const ai_move = try AIPlayMCTS();
+
+    try message.sendMessageF("{d},{d}", .{ai_move[0], ai_move[1]}, writer);
 }
 
 pub fn handle(_: []const u8, writer: std.io.AnyWriter) !void {

--- a/src/commands/turn.zig
+++ b/src/commands/turn.zig
@@ -15,6 +15,32 @@ pub const PlayError = error {
     OCCUPIED,
 };
 
+const AIMapping = *const fn () ai.Threat;
+
+const AIMap: []const AIMapping = &[_]AIMapping{
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    ai.getBotMove5,
+    ai.getBotMove6,
+    ai.getBotMove7,
+    ai.getBotMove8,
+    ai.getBotMove9,
+    ai.getBotMove10,
+    ai.getBotMove11,
+    ai.getBotMove12,
+    ai.getBotMove13,
+    ai.getBotMove14,
+    ai.getBotMove15,
+    ai.getBotMove16,
+    ai.getBotMove17,
+    ai.getBotMove18,
+    ai.getBotMove19,
+    ai.getBotMove20,
+};
+
 pub fn setEnnemyStone(x: u32, y: u32) PlayError!void {
     if (board.game_board.isCoordinatesOutside(x, y)) {
         return PlayError.OUTSIDE;
@@ -26,7 +52,7 @@ pub fn setEnnemyStone(x: u32, y: u32) PlayError!void {
 }
 
 pub fn AIPlay() [2]u16 {
-    const empty_cell = ai.findBestMove(&board.game_board);
+    const empty_cell = @call(.auto, AIMap[board.game_board.width], .{});
     board.game_board.setCellByCoordinates(empty_cell.col, empty_cell.row, board.Cell.own);
     return .{empty_cell.col, empty_cell.row};
 }


### PR DESCRIPTION
AI is now called with comptime size

This pull request includes several changes to the AI evaluation and minimax algorithm in the `src/ai.zig` file, as well as updates to the board and turn handling in the `src/commands` directory. The main changes focus on refactoring the AI evaluation functions to use simpler parameters and adding new functions to handle different board sizes.

Refactoring and simplification:

* [`src/ai.zig`](diffhunk://#diff-c136d7adfc060612eec330a71524df821db5ff14e65c155b8f1ade6f3cbb2e39L14-R40): Refactored functions such as `evaluateDirection`, `evaluateMove`, `findThreats`, `evaluatePosition`, and `minimax` to use simpler parameters like `map`, `col`, `row`, `dx`, `dy`, and `size` instead of complex structures. This change simplifies the code and improves readability. [[1]](diffhunk://#diff-c136d7adfc060612eec330a71524df821db5ff14e65c155b8f1ade6f3cbb2e39L14-R40) [[2]](diffhunk://#diff-c136d7adfc060612eec330a71524df821db5ff14e65c155b8f1ade6f3cbb2e39L64-R73) [[3]](diffhunk://#diff-c136d7adfc060612eec330a71524df821db5ff14e65c155b8f1ade6f3cbb2e39L90-R96) [[4]](diffhunk://#diff-c136d7adfc060612eec330a71524df821db5ff14e65c155b8f1ade6f3cbb2e39L120-R126) [[5]](diffhunk://#diff-c136d7adfc060612eec330a71524df821db5ff14e65c155b8f1ade6f3cbb2e39L147-R156) [[6]](diffhunk://#diff-c136d7adfc060612eec330a71524df821db5ff14e65c155b8f1ade6f3cbb2e39L182-R173) [[7]](diffhunk://#diff-c136d7adfc060612eec330a71524df821db5ff14e65c155b8f1ade6f3cbb2e39L197-R191)

New functions for different board sizes:

* [`src/ai.zig`](diffhunk://#diff-c136d7adfc060612eec330a71524df821db5ff14e65c155b8f1ade6f3cbb2e39R219-R267): Added new functions `getBotMove5` through `getBotMove20` to handle different board sizes, allowing the AI to play on boards of various sizes.

Board and turn handling updates:

* [`src/commands/board.zig`](diffhunk://#diff-5f95b08c39501c03d5ac1215396d38e843c4f4596a26eae406d252c24220cc80L96-R102): Updated the `handleBoard` function to use the new `AIPlay` function from `turn.zig`, which now calls the appropriate bot move function based on the board size.
* [`src/commands/turn.zig`](diffhunk://#diff-bd3f2edb3d71fcc5c8ea20b9fa682a088fc1a8f8c6a1c9d118cf0cee447c9af2R18-R43): Added an `AIMap` array to map board sizes to their corresponding bot move functions and updated the `AIPlay` function to use this mapping. [[1]](diffhunk://#diff-bd3f2edb3d71fcc5c8ea20b9fa682a088fc1a8f8c6a1c9d118cf0cee447c9af2R18-R43) [[2]](diffhunk://#diff-bd3f2edb3d71fcc5c8ea20b9fa682a088fc1a8f8c6a1c9d118cf0cee447c9af2L29-R55)